### PR TITLE
Bump actions/checkout to v3

### DIFF
--- a/.github/linters/.luacheckrc
+++ b/.github/linters/.luacheckrc
@@ -1,1 +1,0 @@
-../../.luacheckrc

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -19,5 +19,6 @@ jobs:
         uses: github/super-linter/slim@v4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LINTER_RULES_PATH: /
           VALIDATE_JSCPD: false
           VALIDATE_PYTHON_BLACK: false

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Lint Code Base
         uses: github/super-linter/slim@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
         neovim_version: ['nightly']
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: date +%F > todays-date
       - name: Restore cache for today's nightly.
         uses: actions/cache@v2


### PR DESCRIPTION
- Bump actions/checkout to v3
- Replace .luacheckrc symlink with LINTER_RULES_PATH setting
