### PR TITLE
Add luarocks-tag-release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,19 @@
+---
+name: "Release"
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  luarocks-release:
+    runs-on: ubuntu-latest
+    name: Luarocks Release
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Luarocks Upload
+        uses: nvim-neorocks/luarocks-tag-release@v4
+        if: env.LUAROCKS_API_KEY != null
+        env:
+          LUAROCKS_API_KEY: ${{ secrets.LUAROCKS_API_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        if: env.LUAROCKS_API_KEY != null
       - name: Luarocks Upload
         uses: nvim-neorocks/luarocks-tag-release@v4
         if: env.LUAROCKS_API_KEY != null

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v3
         if: env.LUAROCKS_API_KEY != null
       - name: Luarocks Upload
-        uses: nvim-neorocks/luarocks-tag-release@v4
+        uses: nvim-neorocks/luarocks-tag-release@v5
         if: env.LUAROCKS_API_KEY != null
         env:
           LUAROCKS_API_KEY: ${{ secrets.LUAROCKS_API_KEY }}

--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ The intention is that you use this template to create a new repository where you
 The template includes the following:
 
 - GitHub workflows to run linters and tests
+- Packaging of tagged releases and upload to [LuaRocks](https://luarocks.org/)
+  if a [`LUAROCKS_API_KEY`](https://luarocks.org/settings/api-keys) is added
+  to the [GitHub Actions secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-a-repository)
 - Minimal test setup
 - EditorConfig
 - A .luacheckrc


### PR DESCRIPTION
Fixes #10.

The upload is skipped if the `LUAROCKS_API_KEY` is not set: https://github.com/mrcjkb/nvim-lua-plugin-template/actions/runs/4589633295/jobs/8104663752