### PR TITLE
ci bump luarocks-tag-release version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v3
         if: env.LUAROCKS_API_KEY != null
       - name: Luarocks Upload
-        uses: nvim-neorocks/luarocks-tag-release@v5
+        uses: nvim-neorocks/luarocks-tag-release@v7
         if: env.LUAROCKS_API_KEY != null
         env:
           LUAROCKS_API_KEY: ${{ secrets.LUAROCKS_API_KEY }}


### PR DESCRIPTION
v5 of luarocks-tag-release will try to run `busted` tests if there's a `.busted` file in the repo root. This does not work when busted is configured to use `nlua`.
With v7, we have dropped support for running tests in favour of the nvim-busted-action.