### PR TITLE
Add note about busted.runner error in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,12 @@ luarocks test spec/path_to_file.lua --local
 busted spec/path_to_file.lua
 ```
 
+If you see an error like `module 'busted.runner' not found`:
+
+```bash
+eval $(luarocks path --no-bin)
+```
+
 [rockspec-format]: https://github.com/luarocks/luarocks/wiki/Rockspec-format
 [luarocks]: https://luarocks.org
 [luarocks-api-key]: https://luarocks.org/settings/api-keys


### PR DESCRIPTION
I thought this was useful - it took me a while to figure out what was going on. Maybe this can save someone else the time.

Ultimately got it from the `nlua` README.