### PR TITLE
Update .busted file's Lua path

### DIFF
--- a/.busted
+++ b/.busted
@@ -2,7 +2,7 @@ return {
   _all = {
     coverage = false,
     lpath = "lua/?.lua;lua/?/init.lua",
-    lua = "nlua",
+    lua = "~/.luarocks/bin/nlua",
   },
   default = {
     verbose = true


### PR DESCRIPTION
This pull request aims to solve issue #17 without the need of using the --lua-version=5.1 argument for local testing.